### PR TITLE
Swap "nut and bolt" semantic

### DIFF
--- a/lib/ratchet/parser.rb
+++ b/lib/ratchet/parser.rb
@@ -22,13 +22,13 @@ module Ratchet
 
     def parse_element(element)
       property = element.attributes[PROPERTY_ATTRIBUTE]
-      bolt(element, property)
+      nut(element, property)
     end
 
-    def bolt(element, property)
+    def nut(element, property)
       [
-        :bolt, :tag, property, element.value,
-        [:bolt, :attrs, element.attributes],
+        :nut, :tag, property, element.value,
+        [:nut, :attrs, element.attributes],
         [:multi, *element.nodes.map(&method(:parse))],
       ]
     end

--- a/lib/ratchet/templates/rails.rb
+++ b/lib/ratchet/templates/rails.rb
@@ -5,7 +5,7 @@ module Ratchet
   module Templates
     Rails = Temple::Templates::Rails(
       Engine,
-      register_as: :nut,
+      register_as: :bolt,
       generator: Temple::Generators::RailsOutputBuffer,
     )
   end

--- a/lib/ratchet/transformer.rb
+++ b/lib/ratchet/transformer.rb
@@ -2,7 +2,7 @@ require 'temple'
 
 module Ratchet
   class Transformer < Temple::Filter
-    def on_bolt_tag(property, tag, attributes, children)
+    def on_nut_tag(property, tag, attributes, children)
       [
         :html, :tag, tag,
         compile(attributes),
@@ -10,7 +10,7 @@ module Ratchet
       ]
     end
 
-    def on_bolt_attrs(attributes)
+    def on_nut_attrs(attributes)
       [:html, :attrs, build_html_attrs(attributes)]
     end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -6,8 +6,8 @@ class ParserTest < Minitest::Test
     assert_parsed(
       '<div>Hello</div>',
       [
-        :bolt, :tag, nil, 'div',
-        [:bolt, :attrs, {}],
+        :nut, :tag, nil, 'div',
+        [:nut, :attrs, {}],
         [:multi, [:static, 'Hello']],
       ],
     )
@@ -17,8 +17,8 @@ class ParserTest < Minitest::Test
     assert_parsed(
       '<div data-prop="title">Hello</div>',
       [
-        :bolt, :tag, 'title', 'div',
-        [:bolt, :attrs, { 'data-prop': 'title' }],
+        :nut, :tag, 'title', 'div',
+        [:nut, :attrs, { 'data-prop': 'title' }],
         [:multi, [:static, 'Hello']],
       ],
     )

--- a/test/transformer_test.rb
+++ b/test/transformer_test.rb
@@ -4,7 +4,7 @@ require 'ratchet/transformer'
 class TransformerTest < Minitest::Test
   def test_content_transformation
     assert_transformed(
-      [:bolt, :tag, 'title', 'div', [:multi], [:multi]],
+      [:nut, :tag, 'title', 'div', [:multi], [:multi]],
       [
         :html, :tag, 'div',
         [:multi],
@@ -15,7 +15,7 @@ class TransformerTest < Minitest::Test
 
   def test_attribute_preservation
     assert_transformed(
-      [:bolt, :tag, nil, 'div', [:bolt, :attrs, { foo: 'bar' }], [:multi]],
+      [:nut, :tag, nil, 'div', [:nut, :attrs, { foo: 'bar' }], [:multi]],
       [
         :html, :tag, 'div',
         [:html, :attrs, [:multi, [:html, :attr, :foo, [:static, 'bar']]]],


### PR DESCRIPTION
I decided I prefer "bolt" as the name of the template as it's "the thing a ratchet cranks on". That leaves "nut" as the internal abstraction which while admittedly cutsie still seems to work as "a fundamental piece underneath ratchet". ¯\_(ツ)_/¯ :joy:

We'll see how it goes...