### PR TITLE
Escape data before binding it to view

### DIFF
--- a/lib/ratchet/engine.rb
+++ b/lib/ratchet/engine.rb
@@ -9,6 +9,7 @@ module Ratchet
     use Parser
     use Transformer
     use Temple::HTML::Fast
+    use Temple::Filters::Escapable
     use(:generator) { options[:generator] }
   end
 end

--- a/lib/ratchet/transformer.rb
+++ b/lib/ratchet/transformer.rb
@@ -28,7 +28,7 @@ module Ratchet
             [:code, "if #{property}.is_a?(Hash) or #{property}.nil?"],
             compile(children),
             [:code, 'else'],
-            [:dynamic, property],
+            [:escape, true, [:dynamic, property]],
             [:code, 'end'],
           ],
         ),

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -32,4 +32,10 @@ class TemplateTest < Minitest::Test
     output = render(source, 'items' => ['first', 'second'])
     assert_equal '<div data-prop="items">first</div><div data-prop="items">second</div>', output
   end
+
+  def test_escaping
+    source = '<div data-prop="foo"></div>'
+    output = render(source, 'foo' => '<span>hacked!</span>')
+    assert_equal '<div data-prop="foo">&lt;span&gt;hacked!&lt;/span&gt;</div>', output
+  end
 end

--- a/test/transformer_test.rb
+++ b/test/transformer_test.rb
@@ -16,7 +16,7 @@ class TransformerTest < Minitest::Test
             [:code, 'if title.is_a?(Hash) or title.nil?'],
             [:static, 'Title'],
             [:code, 'else'],
-            [:dynamic, 'title'],
+            [:escape, true, [:dynamic, 'title']],
             [:code, 'end'],
           ],
         ],


### PR DESCRIPTION
This prevents injection attacks.

[Closes #8]