### PR TITLE
Convert properties to symbols when present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.2
+  - 2.3
 
 notifications:
   email: false

--- a/lib/ratchet/parser.rb
+++ b/lib/ratchet/parser.rb
@@ -31,7 +31,7 @@ module Ratchet
     end
 
     def parse_element(element, scope)
-      property = element.attributes[PROPERTY_ATTRIBUTE]
+      property = element.attributes[PROPERTY_ATTRIBUTE]&.to_sym
       nut(element, scope, property)
     end
 

--- a/test/lib/ratchet/parser_test.rb
+++ b/test/lib/ratchet/parser_test.rb
@@ -53,8 +53,8 @@ class ParserTest < Minitest::Test
     assert_parsed(
       '<div data-prop="title">Hello</div>',
       [:multi, [
-        :nut, :tag, :data, 'title', 'div',
-        [:nut, :attrs, 'title', { 'data-prop' => 'title' }],
+        :nut, :tag, :data, :title, 'div',
+        [:nut, :attrs, :title, { 'data-prop' => 'title' }],
         [:multi, [:static, 'Hello']],
       ]],
     )
@@ -64,13 +64,13 @@ class ParserTest < Minitest::Test
     assert_parsed(
       '<div data-prop="post"><span data-prop="title"></span></div>',
       [:multi, [
-        :nut, :tag, :data, 'post', 'div',
-        [:nut, :attrs, 'post', { 'data-prop' => 'post' }],
+        :nut, :tag, :data, :post, 'div',
+        [:nut, :attrs, :post, { 'data-prop' => 'post' }],
         [
           :multi,
           [
-            :nut, :tag, 'post', 'title', 'span',
-            [:nut, :attrs, 'title', { 'data-prop' => 'title' }],
+            :nut, :tag, :post, :title, 'span',
+            [:nut, :attrs, :title, { 'data-prop' => 'title' }],
             [:multi],
           ],
         ],
@@ -93,18 +93,18 @@ class ParserTest < Minitest::Test
         [
           :multi,
           [
-            :nut, :tag, :data, 'post', 'li',
-            [:nut, :attrs, 'post', { 'data-prop' => 'post' }],
+            :nut, :tag, :data, :post, 'li',
+            [:nut, :attrs, :post, { 'data-prop' => 'post' }],
             [
               :multi,
               [
-                :nut, :tag, 'post', nil, 'div',
+                :nut, :tag, :post, nil, 'div',
                 [:nut, :attrs, nil, {}],
                 [
                   :multi,
                   [
-                    :nut, :tag, 'post', 'title', 'span',
-                    [:nut, :attrs, 'title', { 'data-prop' => 'title' }],
+                    :nut, :tag, :post, :title, 'span',
+                    [:nut, :attrs, :title, { 'data-prop' => 'title' }],
                     [:multi],
                   ],
                 ]

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -33,25 +33,25 @@ class RenderingTest < Minitest::Test
 
   def test_replaces_tag_content
     source = '<div data-prop="title">An Title</div>'
-    output = render(source, P('title' => C('Ratchet')))
+    output = render(source, P(title: C('Ratchet')))
     assert_equal '<div data-prop="title">Ratchet</div>', output
   end
 
   def test_renders_tag_attributes
     source = '<a data-prop="link">Click me!</a>'
-    output = render(source, P('link' => A(href: '/')))
+    output = render(source, P(link: A(href: '/')))
     assert_equal '<a data-prop="link" href="/">Click me!</a>', output
   end
 
   def test_renders_combined_attributes_and_content
     source = '<a data-prop="link">An Link</a>'
-    output = render(source, P('link' => M(C('Click me!'), A(href: '/'))))
+    output = render(source, P(link: M(C('Click me!'), A(href: '/'))))
     assert_equal '<a data-prop="link" href="/">Click me!</a>', output
   end
 
   def test_combined_data_with_nested_properties
     source = '<div data-prop="post"><span data-prop="title"><span></div>'
-    output = render(source, P('post' => M(P('title' => C('lolwat')), A(class: 'fancy'))))
+    output = render(source, P(post: M(P(title: C('lolwat')), A(class: 'fancy'))))
     assert_equal '<div data-prop="post" class="fancy"><span data-prop="title">lolwat</span></div>', output
   end
 
@@ -63,23 +63,23 @@ class RenderingTest < Minitest::Test
 
   def test_nested_properties
     source = '<div data-prop="post"><span data-prop="title">An Title</span></div>'
-    output = render(source, P('post' => P('title' => C('Ratchet'))))
+    output = render(source, P(post: P(title: C('Ratchet'))))
     assert_equal '<div data-prop="post"><span data-prop="title">Ratchet</span></div>', output
   end
 
   def test_iteration
     source = '<div data-prop="items">An Item</div>'
-    output = render(source, P('items' => [C('first'), C('second')]))
+    output = render(source, P(items: [C('first'), C('second')]))
     assert_equal '<div data-prop="items">first</div><div data-prop="items">second</div>', output
   end
 
   def test_escaping
     source = '<div data-prop="foo"></div>'
-    output = render(source, P('foo' => C('<span>hacked!</span>')))
+    output = render(source, P(foo: C('<span>hacked!</span>')))
     assert_equal '<div data-prop="foo">&lt;span&gt;hacked!&lt;/span&gt;</div>', output
 
     source = '<a data-prop="link"></a>'
-    output = render(source, P('link' => A(href: '" class="hacked" lol="')))
+    output = render(source, P(link: A(href: '" class="hacked" lol="')))
     assert_equal '<a data-prop="link" href="&quot; class=&quot;hacked&quot; lol=&quot;"></a>', output
   end
 


### PR DESCRIPTION
This allows us to define data using JSON hash syntax which is a little
nicer. It also may be a little faster to look up symbols, but this isn't
an optimization.

[Closes #22]