### PR TITLE
Rename shortcuts

### DIFF
--- a/lib/ratchet/data.rb
+++ b/lib/ratchet/data.rb
@@ -25,7 +25,7 @@ module Ratchet
       Combined.new(*args)
     end
     module_function :Combined
-    alias_method :M, :Combined
+    alias_method :C, :Combined
 
     def Properties(data)
       Properties.new(data)

--- a/lib/ratchet/data.rb
+++ b/lib/ratchet/data.rb
@@ -19,7 +19,7 @@ module Ratchet
       Content.new(data)
     end
     module_function :Content
-    alias_method :C, :Content
+    alias_method :T, :Content
 
     def Combined(*args)
       Combined.new(*args)

--- a/test/lib/ratchet/data_test.rb
+++ b/test/lib/ratchet/data_test.rb
@@ -26,7 +26,7 @@ class DataTest < Minitest::Test
     content = Combined(T('An Content'), A(foo: 'bar'))
     assert_equal 'An Content', content.to_s
 
-    content = M(T('An Content'), A(foo: 'bar'))
+    content = C(T('An Content'), A(foo: 'bar'))
     assert_equal 'An Content', content.to_s
   end
 
@@ -43,7 +43,7 @@ class DataTest < Minitest::Test
     raw_properties = { haha: raw_content }
     attributes = A(foo: 'bar')
     content = T(raw_content)
-    combined = M(content, attributes)
+    combined = C(content, attributes)
     properties = P(raw_properties)
     none = Ratchet::Data::None.new
 

--- a/test/lib/ratchet/data_test.rb
+++ b/test/lib/ratchet/data_test.rb
@@ -26,7 +26,7 @@ class DataTest < Minitest::Test
     content = Combined(C('An Content'), A(foo: 'bar'))
     assert_equal 'An Content', content.to_s
 
-    content = Combined(C('An Content'), A(foo: 'bar'))
+    content = M(C('An Content'), A(foo: 'bar'))
     assert_equal 'An Content', content.to_s
   end
 

--- a/test/lib/ratchet/data_test.rb
+++ b/test/lib/ratchet/data_test.rb
@@ -18,31 +18,31 @@ class DataTest < Minitest::Test
     content = Content('An Content')
     assert_equal 'An Content', content.to_s
 
-    content = C('An Content')
+    content = T('An Content')
     assert_equal 'An Content', content.to_s
   end
 
   def test_combined_shortcuts
-    content = Combined(C('An Content'), A(foo: 'bar'))
+    content = Combined(T('An Content'), A(foo: 'bar'))
     assert_equal 'An Content', content.to_s
 
-    content = M(C('An Content'), A(foo: 'bar'))
+    content = M(T('An Content'), A(foo: 'bar'))
     assert_equal 'An Content', content.to_s
   end
 
   def test_properties_shortcuts
     properties = Properties(foo: 'bar')
-    assert_equal C('bar'), properties.property(:foo)
+    assert_equal T('bar'), properties.property(:foo)
 
     properties = P(foo: 'bar')
-    assert_equal C('bar'), properties.property(:foo)
+    assert_equal T('bar'), properties.property(:foo)
   end
 
   def test_data_coersion
     raw_content = 'lolwat'
     raw_properties = { haha: raw_content }
     attributes = A(foo: 'bar')
-    content = C(raw_content)
+    content = T(raw_content)
     combined = M(content, attributes)
     properties = P(raw_properties)
     none = Ratchet::Data::None.new

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -33,7 +33,7 @@ class RenderingTest < Minitest::Test
 
   def test_replaces_tag_content
     source = '<div data-prop="title">An Title</div>'
-    output = render(source, P(title: C('Ratchet')))
+    output = render(source, P(title: T('Ratchet')))
     assert_equal '<div data-prop="title">Ratchet</div>', output
   end
 
@@ -63,13 +63,13 @@ class RenderingTest < Minitest::Test
 
   def test_renders_combined_attributes_and_content
     source = '<a data-prop="link">An Link</a>'
-    output = render(source, P(link: M(C('Click me!'), A(href: '/'))))
+    output = render(source, P(link: M(T('Click me!'), A(href: '/'))))
     assert_equal '<a data-prop="link" href="/">Click me!</a>', output
   end
 
   def test_combined_data_with_nested_properties
     source = '<div data-prop="post"><span data-prop="title"><span></div>'
-    output = render(source, P(post: M(P(title: C('lolwat')), A(class: 'fancy'))))
+    output = render(source, P(post: M(P(title: T('lolwat')), A(class: 'fancy'))))
     assert_equal '<div data-prop="post" class="fancy"><span data-prop="title">lolwat</span></div>', output
   end
 
@@ -81,19 +81,19 @@ class RenderingTest < Minitest::Test
 
   def test_nested_properties
     source = '<div data-prop="post"><span data-prop="title">An Title</span></div>'
-    output = render(source, P(post: P(title: C('Ratchet'))))
+    output = render(source, P(post: P(title: T('Ratchet'))))
     assert_equal '<div data-prop="post"><span data-prop="title">Ratchet</span></div>', output
   end
 
   def test_iteration
     source = '<div data-prop="items">An Item</div>'
-    output = render(source, P(items: [C('first'), C('second')]))
+    output = render(source, P(items: [T('first'), T('second')]))
     assert_equal '<div data-prop="items">first</div><div data-prop="items">second</div>', output
   end
 
   def test_escaping
     source = '<div data-prop="foo"></div>'
-    output = render(source, P(foo: C('<span>hacked!</span>')))
+    output = render(source, P(foo: T('<span>hacked!</span>')))
     assert_equal '<div data-prop="foo">&lt;span&gt;hacked!&lt;/span&gt;</div>', output
 
     source = '<a data-prop="link"></a>'

--- a/test/rendering_test.rb
+++ b/test/rendering_test.rb
@@ -51,7 +51,7 @@ class RenderingTest < Minitest::Test
 
   def test_coerces_raw_data_into_combined
     source = '<div data-prop="title">An Title</div>'
-    output = render(source, title: M('Ratchet', class: 'active'))
+    output = render(source, title: C('Ratchet', class: 'active'))
     assert_equal '<div data-prop="title" class="active">Ratchet</div>', output
   end
 
@@ -63,13 +63,13 @@ class RenderingTest < Minitest::Test
 
   def test_renders_combined_attributes_and_content
     source = '<a data-prop="link">An Link</a>'
-    output = render(source, P(link: M(T('Click me!'), A(href: '/'))))
+    output = render(source, P(link: C(T('Click me!'), A(href: '/'))))
     assert_equal '<a data-prop="link" href="/">Click me!</a>', output
   end
 
   def test_combined_data_with_nested_properties
     source = '<div data-prop="post"><span data-prop="title"><span></div>'
-    output = render(source, P(post: M(P(title: T('lolwat')), A(class: 'fancy'))))
+    output = render(source, P(post: C(P(title: T('lolwat')), A(class: 'fancy'))))
     assert_equal '<div data-prop="post" class="fancy"><span data-prop="title">lolwat</span></div>', output
   end
 


### PR DESCRIPTION
Rename content's `C` to `T`, so that combine's `M` can be renamed to `C`. Turns out the content shortcut is almost never needed since data is coerced when looking up properties and such :sparkles: